### PR TITLE
Fix xi -> q mapping in testSample

### DIFF
--- a/UQit/sampling.py
+++ b/UQit/sampling.py
@@ -220,9 +220,10 @@ class testSample:
         if self.sampleType=='unifSpaced':
            q_=np.linspace(self.qBound[0],self.qBound[1],n) 
         elif self.sampleType=='GLL':
-             self.xiBound=[-1,1]
-             xi_,w_=nodes.gllPts(n) 
-             q_=xi_*(self.qBound[1]-self.qBound[0])+self.qBound[0]
+            self.xiBound=[-1,1]
+            xi_,w_=nodes.gllPts(n)
+            q_ = (xi_ - self.xiBound[0]) / (self.xiBound[1] - self.xiBound[0]) * \
+                 (self.qBound[1] - self.qBound[0]) + self.qBound[0]
         elif self.sampleType=='unifRand':
            if self.GQdistType!='Unif': 
               raise ValueError("#ERROR @ testSample: sampleType 'unifRand' should be with GQdistType 'Unif' or ''.")


### PR DESCRIPTION
I believe the GLL sampling type for `testSample` is currently buggy. As I understand it, for `testSample`, we are supposed to generate q, and then map it to xi. However, for the GLL case we end up doing both, starting with generating xi, mapping to q, and then mapping back. I think the first map from xi to q is incorrect.

`q_=xi_*(self.qBound[1]-self.qBound[0])+self.qBound[0]`

Assume `qBound = [0, 1]`, since `xi_` is in [-1, 1] for GLL, it follows that the bounds for `q_` will be `xi_*(1 - 0) + 0 = xi_`, which is clearly wrong.
To fix this, I just copied the mapping code from the `xi2q_map` function in `trainSample`. I think this does the job!